### PR TITLE
Add dashboard, calendar, leads and profile views

### DIFF
--- a/Public/calendar.html
+++ b/Public/calendar.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Calendar</title>
+</head>
+<body>
+  <h1>Calendar</h1>
+  <nav>
+    <a href="/index.html">Dashboard</a> |
+    <a href="/calendar.html">Calendar</a> |
+    <a href="/leads.html">Leads</a> |
+    <a href="/profile.html">Profile</a>
+  </nav>
+  <p>This is the calendar page.</p>
+</body>
+</html>

--- a/Public/index.html
+++ b/Public/index.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Insurance CRM Dashboard</title>
+</head>
+<body>
+  <h1>Dashboard</h1>
+  <nav>
+    <a href="/index.html">Dashboard</a> |
+    <a href="/calendar.html">Calendar</a> |
+    <a href="/leads.html">Leads</a> |
+    <a href="/profile.html">Profile</a>
+  </nav>
+  <p>Welcome to the Insurance CRM dashboard.</p>
+</body>
+</html>

--- a/Public/leads.html
+++ b/Public/leads.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Insurance CRM</title>
+  <title>Leads</title>
   <script>
     async function fetchClients() {
       const res = await fetch('/api/clients');
@@ -39,7 +39,13 @@
   </script>
 </head>
 <body>
-  <h1>Insurance CRM</h1>
+  <h1>Leads</h1>
+  <nav>
+    <a href="/index.html">Dashboard</a> |
+    <a href="/calendar.html">Calendar</a> |
+    <a href="/leads.html">Leads</a> |
+    <a href="/profile.html">Profile</a>
+  </nav>
 
   <h2>Add Client</h2>
   <form id="clientForm" onsubmit="addClient(event)">

--- a/Public/profile.html
+++ b/Public/profile.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Profile</title>
+</head>
+<body>
+  <h1>Profile</h1>
+  <nav>
+    <a href="/index.html">Dashboard</a> |
+    <a href="/calendar.html">Calendar</a> |
+    <a href="/leads.html">Leads</a> |
+    <a href="/profile.html">Profile</a>
+  </nav>
+  <p>This is the profile page.</p>
+</body>
+</html>

--- a/README.md
+++ b/README.md
@@ -1,13 +1,6 @@
 # Insurance CRM
 
- anszxq-codex/build-crm-app-for-insurance-agents
 This project provides a simple CRM application for insurance agents. It includes a Node.js backend and a minimal frontend written in vanilla HTML/JavaScript.
-
-## Getting Started
-
-1. Start the server:
-
-This project provides a simple CRM application for insurance agents. It includes a Node.js backend built with Express and a minimal frontend written in vanilla HTML/JavaScript.
 
 ## Getting Started
 
@@ -15,26 +8,17 @@ This project provides a simple CRM application for insurance agents. It includes
    ```bash
    npm install
    ```
-
 2. Start the server:
- main
    ```bash
    node server.js
    ```
-
-anszxq-codex/build-crm-app-for-insurance-agents
-2. Open your browser and navigate to `http://localhost:3000` to use the CRM.
-
-3. Open your browser and navigate to `http://localhost:3000` to use the CRM.
- main
+3. Open your browser and navigate to `http://localhost:3000`.
 
 ## Features
 
-- Add new clients with name, email, and phone number.
+- Dashboard, calendar, leads and profile pages.
+- Add new clients with name, email, and phone number from the leads page.
 - View a list of existing clients.
- anszxq-codex/build-crm-app-for-insurance-agents
 - Client data is persisted to `db.json`.
-
-main
 
 This is a foundation for future enhancements such as team management and dashboards.

--- a/package.json
+++ b/package.json
@@ -2,12 +2,10 @@
   "name": "insurance-crm",
   "version": "1.0.0",
   "main": "server.js",
-anszxq-codex/build-crm-app-for-insurance-agents
   "license": "MIT",
   "dependencies": {
     "body-parser": "^1.20.2",
     "cors": "^2.8.5",
     "express": "^4.18.2"
   }
-main
 }

--- a/server.js
+++ b/server.js
@@ -1,46 +1,23 @@
- anszxq-codex/build-crm-app-for-insurance-agents
-const path = require('path');
-const express = require('./express');
-const cors = require('./cors');
-const db = require('./db');
-
-const app = express();
-app.use(cors());
-app.use(express.json());
-app.use(express.static(path.join(__dirname, 'Public')));
-
-// Persisted clients are stored in db.json using our simple db module
-
-app.get('/api/clients', (req, res) => {
-  res.json(db.getClients());
 const express = require('express');
 const bodyParser = require('body-parser');
 const path = require('path');
 const cors = require('cors');
+const db = require('./db');
 
 const app = express();
 app.use(cors());
 app.use(bodyParser.json());
 app.use(express.static(path.join(__dirname, 'Public')));
 
-let clients = [];
-
 app.get('/api/clients', (req, res) => {
-  res.json(clients);
-main
+  res.json(db.getClients());
 });
 
 app.post('/api/clients', (req, res) => {
   const { name, email, phone } = req.body;
-anszxq-codex/build-crm-app-for-insurance-agents
   const id = db.getClients().length + 1;
   const client = { id, name, email, phone };
   db.addClient(client);
-
-  const id = clients.length + 1;
-  const client = { id, name, email, phone };
-  clients.push(client);
-main
   res.status(201).json(client);
 });
 


### PR DESCRIPTION
## Summary
- add new views and navigation
- move leads code to its own page
- clean up server.js using Express
- fix and simplify README

## Testing
- `npm install`
- `node server.js` *(started then stopped to verify startup)*

------
https://chatgpt.com/codex/tasks/task_e_684740c7f1ac832e892bae878d853fcc