### PR TITLE
Implement admin login with session routes

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,8 +13,10 @@ This project provides a simple CRM application for insurance agents. It includes
    node server.js
    ```
 
-
 3. Open your browser and navigate to `http://localhost:3000` to use the CRM.
+   Use the following credentials to log in:
+   - **Email:** `admin@gmail.com`
+   - **Password:** `admin123`
 
 ## Features
 

--- a/server.js
+++ b/server.js
@@ -8,9 +8,38 @@ const db = require('./db');
 const app = express();
 app.use(cors());
 app.use(bodyParser.json());
+app.use(
+  session({
+    secret: 'change-this-secret',
+    resave: false,
+    saveUninitialized: false
+  })
+);
 app.use(express.static(path.join(__dirname, 'Public')));
 
 // Persisted clients are stored in db.json using our simple db module
+
+app.post('/api/login', (req, res) => {
+  const { email, password } = req.body;
+  if (email === 'admin@gmail.com' && password === 'admin123') {
+    req.session.user = { email };
+    return res.json({ email });
+  }
+  res.status(401).json({ message: 'Invalid credentials' });
+});
+
+app.post('/api/logout', (req, res) => {
+  req.session.destroy(() => {
+    res.status(204).end();
+  });
+});
+
+app.get('/api/me', (req, res) => {
+  if (req.session.user) {
+    return res.json(req.session.user);
+  }
+  res.status(401).end();
+});
 
 app.get('/api/clients', (req, res) => {
   res.json(db.getClients());


### PR DESCRIPTION
## Summary
- add session middleware and login/logout endpoints
- document admin credentials in the README

## Testing
- `npm test` *(fails: Missing script)*
- `node server.js` and manual `curl` to /api/login, /api/me, /api/logout

------
https://chatgpt.com/codex/tasks/task_e_68474b24c988832eaef9d35ee5f51ae5