### PR TITLE
Add basic user registration

### DIFF
--- a/Public/register.html
+++ b/Public/register.html
@@ -3,42 +3,36 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Login</title>
+  <title>Register</title>
   <link rel="stylesheet" href="/style.css">
   <script>
-    async function login(event) {
+    async function register(event) {
       event.preventDefault();
       const email = document.getElementById('email').value;
       const password = document.getElementById('password').value;
-      const res = await fetch('/api/login', {
+      const res = await fetch('/api/register', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ email, password })
       });
       if (res.ok) {
-        window.location.href = '/index.html';
+        alert('Registration successful. Please login.');
+        window.location.href = '/login.html';
       } else {
-        alert('Invalid credentials');
+        const data = await res.json();
+        alert(data.message || 'Registration failed');
       }
     }
-    async function check() {
-      const res = await fetch('/api/me');
-      if (res.status === 200) {
-        window.location.href = '/index.html';
-      }
-    }
-    document.addEventListener('DOMContentLoaded', check);
   </script>
 </head>
 <body>
   <main>
-    <h1>Login</h1>
-    <form onsubmit="login(event)">
+    <h1>Register</h1>
+    <form onsubmit="register(event)">
       <input id="email" placeholder="Email" required>
       <input id="password" type="password" placeholder="Password" required>
-      <button type="submit">Login</button>
+      <button type="submit">Register</button>
     </form>
-    <p>Don't have an account? <a href="/register.html">Register here</a>.</p>
   </main>
 </body>
 </html>

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ This project provides a simple CRM application for insurance agents. It includes
 
 4. Open your browser and navigate to `http://localhost:3000` to use the CRM.
 
-   Use the following credentials to log in:
+   You can register a new account from the login page or use the default admin credentials:
    - **Email:** `admin@gmail.com`
    - **Password:** `admin123`
 

--- a/db.js
+++ b/db.js
@@ -8,7 +8,7 @@ function load() {
     const data = fs.readFileSync(DB_FILE, 'utf8');
     return JSON.parse(data);
   } catch (err) {
-    return { clients: [] };
+    return { clients: [], users: [] };
   }
 }
 
@@ -24,6 +24,13 @@ module.exports = {
   },
   addClient(client) {
     db.clients.push(client);
+    save(db);
+  },
+  getUsers() {
+    return db.users;
+  },
+  addUser(user) {
+    db.users.push(user);
     save(db);
   }
 };

--- a/db.json
+++ b/db.json
@@ -12,5 +12,11 @@
       "email": "elias@gmail.com",
       "phone": "46417944"
     }
+  ],
+  "users": [
+    {
+      "email": "admin@gmail.com",
+      "password": "admin123"
+    }
   ]
 }

--- a/server.js
+++ b/server.js
@@ -21,11 +21,21 @@ app.use(express.static(path.join(__dirname, 'Public')));
 
 app.post('/api/login', (req, res) => {
   const { email, password } = req.body;
-  if (email === 'admin@gmail.com' && password === 'admin123') {
-    req.session.user = { email };
-    return res.json({ email });
+  const user = db.getUsers().find(u => u.email === email && u.password === password);
+  if (user) {
+    req.session.user = { email: user.email };
+    return res.json({ email: user.email });
   }
   res.status(401).json({ message: 'Invalid credentials' });
+});
+
+app.post('/api/register', (req, res) => {
+  const { email, password } = req.body;
+  if (db.getUsers().some(u => u.email === email)) {
+    return res.status(400).json({ message: 'User already exists' });
+  }
+  db.addUser({ email, password });
+  res.status(201).end();
 });
 
 app.post('/api/logout', (req, res) => {


### PR DESCRIPTION
## Summary
- create a new `register.html` page
- allow sign up via new `/api/register` route
- store users in `db.json`
- update login page and README

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68474f77c3cc832e9708ad295184fecf