### PR TITLE
Add policy management

### DIFF
--- a/Public/calendar.html
+++ b/Public/calendar.html
@@ -55,6 +55,7 @@
     <a href="/leads.html">Leads</a> |
     <a href="/notes.html">Notes</a> |
     <a href="/profile.html">Profile</a> |
+    <a href="/policies.html">Policies</a> |
     <a href="#" onclick="logout()">Logout</a>
   </nav>
   <main>

--- a/Public/index.html
+++ b/Public/index.html
@@ -93,6 +93,7 @@
     <a href="/leads.html">Leads</a> |
     <a href="/notes.html">Notes</a> |
     <a href="/profile.html">Profile</a> |
+    <a href="/policies.html">Policies</a> |
     <a href="#" onclick="logout()">Logout</a>
   </nav>
   <main>

--- a/Public/leads.html
+++ b/Public/leads.html
@@ -63,6 +63,7 @@
     <a href="/leads.html">Leads</a> |
     <a href="/notes.html">Notes</a> |
     <a href="/profile.html">Profile</a> |
+    <a href="/policies.html">Policies</a> |
     <a href="#" onclick="logout()">Logout</a>
   </nav>
   <main>

--- a/Public/notes.html
+++ b/Public/notes.html
@@ -53,6 +53,7 @@
     <a href="/calendar.html">Calendar</a> |
     <a href="/leads.html">Leads</a> |
     <a href="/profile.html">Profile</a> |
+    <a href="/policies.html">Policies</a> |
     <a href="/notes.html">Notes</a> |
     <a href="#" onclick="logout()">Logout</a>
   </nav>

--- a/Public/policies.html
+++ b/Public/policies.html
@@ -1,0 +1,106 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Policies</title>
+  <link rel="stylesheet" href="/style.css">
+  <script>
+    async function requireAuth() {
+      const res = await fetch('/api/me');
+      if (res.status !== 200) {
+        window.location.href = '/login.html';
+      }
+    }
+    async function logout() {
+      await fetch('/api/logout', { method: 'POST' });
+      window.location.href = '/login.html';
+    }
+    document.addEventListener('DOMContentLoaded', requireAuth);
+  </script>
+  <script>
+    async function fetchPolicies() {
+      const res = await fetch('/api/policies');
+      const policies = await res.json();
+      displayPolicies(policies);
+    }
+
+    function displayPolicies(policies) {
+      const tbody = document.getElementById('policies');
+      tbody.innerHTML = '';
+      const counts = {};
+      policies.forEach(p => {
+        const tr = document.createElement('tr');
+        tr.innerHTML = `<td>${p.company || ''}</td><td>${p.number || p.policyNumber || ''}</td><td>${p.category || ''}</td>`;
+        tbody.appendChild(tr);
+        if (p.company) counts[p.company] = (counts[p.company] || 0) + 1;
+      });
+      const cmp = document.getElementById('comparison');
+      cmp.innerHTML = '';
+      for (const [comp, count] of Object.entries(counts)) {
+        const li = document.createElement('li');
+        li.textContent = `${comp}: ${count}`;
+        cmp.appendChild(li);
+      }
+    }
+
+    async function importPolicies(event) {
+      event.preventDefault();
+      const fileInput = document.getElementById('file');
+      const category = document.getElementById('category').value;
+      const file = fileInput.files[0];
+      if (!file) return;
+      const text = await file.text();
+      let data;
+      if (file.name.endsWith('.csv')) {
+        const lines = text.trim().split(/\r?\n/).filter(Boolean);
+        const entries = lines.slice(1);
+        data = entries.map(l => {
+          const [company, number] = l.split(',');
+          return { company: company.trim(), number: number.trim(), category };
+        });
+      } else {
+        data = JSON.parse(text);
+        if (!Array.isArray(data)) data = [data];
+        data = data.map(p => ({ ...p, category }));
+      }
+      for (const p of data) {
+        await fetch('/api/policies', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify(p)
+        });
+      }
+      document.getElementById('policyForm').reset();
+      fetchPolicies();
+    }
+
+    document.addEventListener('DOMContentLoaded', fetchPolicies);
+  </script>
+</head>
+<body>
+  <nav>
+    <a href="/index.html">Dashboard</a> |
+    <a href="/calendar.html">Calendar</a> |
+    <a href="/leads.html">Leads</a> |
+    <a href="/notes.html">Notes</a> |
+    <a href="/profile.html">Profile</a> |
+    <a href="/policies.html">Policies</a> |
+    <a href="#" onclick="logout()">Logout</a>
+  </nav>
+  <main>
+    <h1>Policies</h1>
+    <form id="policyForm" onsubmit="importPolicies(event)">
+      <input type="file" id="file" accept=".csv,application/json" required>
+      <input id="category" placeholder="Category" required>
+      <button type="submit">Import</button>
+    </form>
+    <table>
+      <thead><tr><th>Company</th><th>Number</th><th>Category</th></tr></thead>
+      <tbody id="policies"></tbody>
+    </table>
+    <h2>Policies by Company</h2>
+    <ul id="comparison"></ul>
+  </main>
+</body>
+</html>

--- a/Public/profile.html
+++ b/Public/profile.html
@@ -26,6 +26,7 @@
     <a href="/leads.html">Leads</a> |
     <a href="/notes.html">Notes</a> |
     <a href="/profile.html">Profile</a> |
+    <a href="/policies.html">Policies</a> |
     <a href="#" onclick="logout()">Logout</a>
   </nav>
   <main>

--- a/db.js
+++ b/db.js
@@ -6,21 +6,9 @@ const DB_FILE = path.join(__dirname, 'db.json');
 function load() {
   try {
     const data = fs.readFileSync(DB_FILE, 'utf8');
-  return JSON.parse(data);
-  } catch (err) {
-
-    return { clients: [], meetings: [], users: [] };
-
-
-    return { clients: [], users: [], calls: [] };
-
-
-    return { clients: [], meetings: [] };
-
-    return { clients: [], users: [] };
-
-
-
+    return JSON.parse(data);
+  } catch {
+    return { clients: [], meetings: [], notes: [], users: [], calls: [], policies: [] };
   }
 }
 
@@ -31,6 +19,7 @@ function save(data) {
 const db = load();
 
 module.exports = {
+  // clients
   getClients() {
     return db.clients;
   },
@@ -38,7 +27,6 @@ module.exports = {
     db.clients.push(client);
     save(db);
   },
-
   updateClient(id, updates) {
     const idx = db.clients.findIndex(c => c.id === id);
     if (idx !== -1) {
@@ -49,7 +37,7 @@ module.exports = {
     return null;
   },
 
-
+  // meetings
   getMeetings() {
     return db.meetings;
   },
@@ -58,7 +46,7 @@ module.exports = {
     save(db);
   },
 
-
+  // users
   getUsers() {
     return db.users;
   },
@@ -67,21 +55,41 @@ module.exports = {
     save(db);
   },
 
+  // notes
   getNotes() {
     return db.notes || [];
   },
   addNote(note) {
-    if (!db.notes) {
-      db.notes = [];
-    }
+    if (!db.notes) db.notes = [];
     db.notes.push(note);
     save(db);
   },
+
+  // calls
   addCall(call) {
     db.calls.push(call);
     save(db);
   },
   getCalls() {
     return db.calls;
+  },
+
+  // policies
+  getPolicies() {
+    return db.policies || [];
+  },
+  addPolicy(policy) {
+    if (!db.policies) db.policies = [];
+    db.policies.push(policy);
+    save(db);
+  },
+  updatePolicy(id, updates) {
+    const idx = db.policies.findIndex(p => p.id === id);
+    if (idx !== -1) {
+      db.policies[idx] = { ...db.policies[idx], ...updates };
+      save(db);
+      return db.policies[idx];
+    }
+    return null;
   }
 };

--- a/db.json
+++ b/db.json
@@ -33,5 +33,6 @@
       "password": "$2b$10$OyuNRj2oGXzk2hnLQilfnerRgrmtJHLXijiCQa4v5k3jCqW/1.yKG"
     }
   ],
-  "calls": []
+  "calls": [],
+  "policies": []
 }

--- a/server.js
+++ b/server.js
@@ -129,6 +129,27 @@ app.post('/api/notes', (req, res) => {
   db.addNote(note);
   res.status(201).json(note);
 });
+
+// Policy management
+app.get('/api/policies', (req, res) => {
+  res.json(db.getPolicies());
+});
+
+app.post('/api/policies', (req, res) => {
+  const id = db.getPolicies().length + 1;
+  const policy = { id, ...req.body };
+  db.addPolicy(policy);
+  res.status(201).json(policy);
+});
+
+app.put('/api/policies/:id', (req, res) => {
+  const id = parseInt(req.params.id, 10);
+  const updated = db.updatePolicy(id, req.body);
+  if (!updated) {
+    return res.status(404).end();
+  }
+  res.json(updated);
+});
 const PORT = process.env.PORT || 3000;
 app.listen(PORT, () => {
   console.log(`Server listening on port ${PORT}`);

--- a/test/policies.test.js
+++ b/test/policies.test.js
@@ -1,0 +1,47 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const { spawn } = require('node:child_process');
+const { setTimeout: delay } = require('node:timers/promises');
+
+async function startServer() {
+  const port = 3000 + Math.floor(Math.random() * 1000);
+  const child = spawn('node', ['server.js'], { env: { ...process.env, PORT: port } });
+  await delay(500);
+  return { child, port };
+}
+
+async function stopServer(server) {
+  server.child.kill();
+  await delay(100);
+}
+
+test('policies endpoints work', { concurrency: false }, async () => {
+  const server = await startServer();
+  try {
+    const addRes = await fetch(`http://localhost:${server.port}/api/policies`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ company: 'Acme', number: 'XYZ', category: 'Life' })
+    });
+    assert.equal(addRes.status, 201);
+    const added = await addRes.json();
+    assert.equal(added.company, 'Acme');
+
+    const updRes = await fetch(`http://localhost:${server.port}/api/policies/${added.id}`, {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ category: 'Health' })
+    });
+    assert.equal(updRes.status, 200);
+    const updated = await updRes.json();
+    assert.equal(updated.category, 'Health');
+
+    const listRes = await fetch(`http://localhost:${server.port}/api/policies`);
+    assert.equal(listRes.status, 200);
+    const list = await listRes.json();
+    assert.ok(Array.isArray(list));
+    assert.ok(list.find(p => p.id === added.id && p.category === 'Health'));
+  } finally {
+    await stopServer(server);
+  }
+});


### PR DESCRIPTION
## Summary
- expand database with `policies` support
- add policy CRUD helpers
- expose API routes for listing, creating and updating policies
- create `policies.html` for importing and comparing policies
- link to `Policies` page from navigation
- test new policy endpoints

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684758e98d0c832eaace1aeb267a1e00