### PR TITLE
Add calendar tasks

### DIFF
--- a/Public/calendar.html
+++ b/Public/calendar.html
@@ -18,7 +18,9 @@
     }
     document.addEventListener('DOMContentLoaded', () => {
       requireAuth();
+      buildCalendar(new Date());
       fetchMeetings();
+      fetchTasks();
     });
 
     async function fetchMeetings() {
@@ -30,6 +32,18 @@
         const li = document.createElement('li');
         const date = new Date(m.datetime);
         li.textContent = `${date.toLocaleString()} - ${m.title}`;
+        list.appendChild(li);
+      });
+    }
+
+    async function fetchTasks() {
+      const res = await fetch('/api/tasks');
+      const tasks = await res.json();
+      const list = document.getElementById('tasks');
+      list.innerHTML = '';
+      tasks.forEach(t => {
+        const li = document.createElement('li');
+        li.textContent = t.title + (t.due ? ` (due ${t.due})` : '');
         list.appendChild(li);
       });
     }
@@ -46,6 +60,41 @@
       document.getElementById('meetingForm').reset();
       fetchMeetings();
     }
+
+    async function addTask(event) {
+      event.preventDefault();
+      const title = document.getElementById('taskTitle').value;
+      const due = document.getElementById('taskDue').value;
+      await fetch('/api/tasks', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ title, due })
+      });
+      document.getElementById('taskForm').reset();
+      fetchTasks();
+    }
+
+    function buildCalendar(date) {
+      const grid = document.getElementById('calendarGrid');
+      grid.innerHTML = '';
+      const year = date.getFullYear();
+      const month = date.getMonth();
+      const first = new Date(year, month, 1);
+      const last = new Date(year, month + 1, 0);
+      const startDay = first.getDay();
+      for (let i = 0; i < startDay; i++) {
+        grid.appendChild(document.createElement('div'));
+      }
+      for (let d = 1; d <= last.getDate(); d++) {
+        const cell = document.createElement('div');
+        cell.textContent = d;
+        const today = new Date();
+        if (today.getFullYear() === year && today.getMonth() === month && today.getDate() === d) {
+          cell.classList.add('today');
+        }
+        grid.appendChild(cell);
+      }
+    }
   </script>
 </head>
 <body>
@@ -60,15 +109,28 @@
   </nav>
   <main>
     <h1>Calendar</h1>
-    <h2>Add Meeting</h2>
-    <form id="meetingForm" onsubmit="addMeeting(event)">
-      <input id="title" placeholder="Title" required>
-      <input id="datetime" type="datetime-local" required>
-      <button type="submit">Add</button>
-    </form>
+    <div class="calendar-wrapper">
+      <div class="task-list">
+        <h2>Add Task</h2>
+        <form id="taskForm" onsubmit="addTask(event)">
+          <input id="taskTitle" placeholder="Task" required>
+          <input id="taskDue" type="date">
+          <button type="submit">Add</button>
+        </form>
+        <h2>Tasks</h2>
+        <ul id="tasks"></ul>
 
-    <h2>Upcoming Meetings</h2>
-    <ul id="meetings"></ul>
+        <h2>Add Meeting</h2>
+        <form id="meetingForm" onsubmit="addMeeting(event)">
+          <input id="title" placeholder="Title" required>
+          <input id="datetime" type="datetime-local" required>
+          <button type="submit">Add</button>
+        </form>
+        <h2>Upcoming Meetings</h2>
+        <ul id="meetings"></ul>
+      </div>
+      <div class="calendar-grid" id="calendarGrid"></div>
+    </div>
   </main>
 </body>
 </html>

--- a/Public/style.css
+++ b/Public/style.css
@@ -74,3 +74,31 @@ li {
 .dashboard-card h2 {
   margin-top: 0;
 }
+
+/* Calendar and tasks layout */
+.calendar-wrapper {
+  display: flex;
+  gap: 20px;
+}
+
+.task-list {
+  width: 250px;
+}
+
+.calendar-grid {
+  display: grid;
+  flex: 1;
+  grid-template-columns: repeat(7, 1fr);
+  gap: 5px;
+}
+
+.calendar-grid div {
+  background: #fff;
+  padding: 5px;
+  border: 1px solid #ccc;
+  min-height: 80px;
+}
+
+.calendar-grid .today {
+  background: #e0f7fa;
+}

--- a/db.js
+++ b/db.js
@@ -8,7 +8,7 @@ function load() {
     const data = fs.readFileSync(DB_FILE, 'utf8');
     return JSON.parse(data);
   } catch {
-    return { clients: [], meetings: [], notes: [], users: [], calls: [], policies: [] };
+    return { clients: [], meetings: [], notes: [], tasks: [], users: [], calls: [], policies: [] };
   }
 }
 
@@ -62,6 +62,16 @@ module.exports = {
   addNote(note) {
     if (!db.notes) db.notes = [];
     db.notes.push(note);
+    save(db);
+  },
+
+  // tasks
+  getTasks() {
+    return db.tasks || [];
+  },
+  addTask(task) {
+    if (!db.tasks) db.tasks = [];
+    db.tasks.push(task);
     save(db);
   },
 

--- a/db.json
+++ b/db.json
@@ -34,5 +34,6 @@
     }
   ],
   "calls": [],
-  "policies": []
+  "policies": [],
+  "tasks": []
 }

--- a/server.js
+++ b/server.js
@@ -130,6 +130,19 @@ app.post('/api/notes', (req, res) => {
   res.status(201).json(note);
 });
 
+// Task management
+app.get('/api/tasks', (req, res) => {
+  res.json(db.getTasks());
+});
+
+app.post('/api/tasks', (req, res) => {
+  const { title, due } = req.body;
+  const id = db.getTasks().length + 1;
+  const task = { id, title, due, completed: false };
+  db.addTask(task);
+  res.status(201).json(task);
+});
+
 // Policy management
 app.get('/api/policies', (req, res) => {
   res.json(db.getPolicies());


### PR DESCRIPTION
## Summary
- persist tasks in db
- expose /api/tasks API endpoints
- expand calendar page with task list and month view
- add layout styles for calendar page

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68475afe75b8832e9c181da86c5d741a